### PR TITLE
ramips: add support for JCG Q20 (#6850)

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -40,6 +40,9 @@ ravpower,rp-wd03)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x4000" "0x1000" "0x1000"
 	;;
+jcg,q20)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
 linksys,ea7300-v1|\
 linksys,ea7300-v2|\
 linksys,ea7500-v2|\

--- a/target/linux/ramips/dts/mt7621_jcg_q20.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_q20.dts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "jcg,q20", "mediatek,mt7621-soc";
+	model = "JCG Q20";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "q20:red:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: status_blue {
+			label = "q20:blue:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x5900000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "kernel";
+			reg = <0x180000 0x400000>;
+		};
+
+		ubiconcat0: partition@580000 {
+			label = "ubiconcat0";
+			reg = <0x580000 0x1c00000>;
+		};
+
+		partition@2180000 {
+			label = "firmware_backup";
+			reg = <0x2180000 0x2000000>;
+		};
+
+		partition@4180000 {
+			label = "rootfs_data_back";
+			reg = <0x4180000 0x80000>;
+			read-only;
+		};
+
+		partition@4200000 {
+			label = "nvram_config";
+			reg = <0x4200000 0x80000>;
+			read-only;
+		};
+
+		ubiconcat1: partition@4280000 {
+			label = "ubiconcat1";
+			reg = <0x4280000 0x3d00000>;
+		};
+
+		/*
+		 * last 512 KiB are for the bad block table
+		 */
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x3fff4>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0x3fffa>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -508,6 +508,22 @@ define Device/jcg_jhr-ac876m
 endef
 TARGET_DEVICES += jcg_jhr-ac876m
 
+define Device/jcg_q20
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 91136k
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  DEVICE_VENDOR := JCG
+  DEVICE_MODEL := Q20
+  DEVICE_PACKAGES := kmod-mt7915e wpad-openssl uboot-envtools
+endef
+TARGET_DEVICES += jcg_q20
+
 define Device/jcg_y2
   $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -95,7 +95,7 @@ xiaomi,mi-router-ac2100)
 	ucidef_set_led_switch "wan" "wan" "$boardname:blue:wan" "switch0" "0x1"
 	;;
 xiaomi,mi-router-cr6606)
-	ucidef_set_led_netdev "internet" "internet" "mi-router-cr6606:blue:net" "wan"
+	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:net" "wan"
 	;;
 xiaomi,redmi-router-ac2100)
 	ucidef_set_led_switch "wan" "wan" "$boardname:white:wan" "switch0" "0x1"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ramips_setup_interfaces()
 		;;
 	asiarf,ap7621-nv1|\
 	glinet,gl-mt1300|\
+	jcg,q20|\
 	lenovo,newifi-d1|\
 	mikrotik,routerboard-m33g|\
 	xiaomi,mir3g-v2)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -14,6 +14,10 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1 > /sys${DEVPATH}/macaddress
 		;;
+	jcg,q20)
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0x4)" > /sys${DEVPATH}/macaddress
+		;;
 	linksys,ea7500-v2)
 		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -45,6 +45,7 @@ platform_do_upgrade() {
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
 	hiwifi,hc5962|\
+	jcg,q20|\
 	linksys,ea7500-v2|\
 	netgear,r6220|\
 	netgear,r6260|\


### PR DESCRIPTION
JCG Q20 is an AX 1800M router.

Hardware specs:
  SoC: MediaTek MT7621AT
  Flash: Winbond W29N01HV 128 MiB
  RAM: Winbond W632GU6NB-11 256 MiB
  WiFi: MT7915 2.4/5 GHz 2T2R
  Ethernet: 10/100/1000 Mbps x3
  LED: Status (red / blue)
  Button: Reset, WPS
  Power: DC 12V,1A

Flash instructions:
  Upload factory.bin in stock firmware's upgrade page,
  do not preserve settings.

Signed-off-by: AmadeusGhost <amadeus@jmu.edu.cn>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
