### PR TITLE
curl: update to version 7.77.0 (security fix) (#6952)

### DIFF
--- a/package/network/utils/curl/Makefile
+++ b/package/network/utils/curl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=7.76.0
+PKG_VERSION:=7.77.0
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \
 	https://curl.mirror.anstey.ca/ \
 	https://curl.askapache.com/download/ \
 	https://curl.haxx.se/download/
-PKG_HASH:=6302e2d75c59cdc6b35ce3fbe716481dd4301841bbb5fd71854653652a014fc8
+PKG_HASH:=0f64582c54282f31c0de9f0a1a596b182776bd4df9a4c4a2a41bbeb54f62594b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Fixes:
CVE-2021-22897
CVE-2021-22898
CVE-2021-22901

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>

Co-authored-by: Jan Pavlinec <jan.pavlinec@nic.cz>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
