### PR TITLE
ath10k: re-added 256qam support (#7200)

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -19,7 +19,7 @@ ifdef CONFIG_PACKAGE_MAC80211_DEBUGFS
 	ATH9K_DEBUGFS \
 	ATH9K_HTC_DEBUGFS \
 	ATH10K_DEBUGFS \
-  ATH11K_DEBUGFS \
+	ATH11K_DEBUGFS \
 	CARL9170_DEBUGFS \
 	ATH5K_DEBUG \
 	ATH6KL_DEBUG \
@@ -29,7 +29,7 @@ endif
 ifdef CONFIG_PACKAGE_MAC80211_TRACING
   config-y += \
 	ATH10K_TRACING \
-  ATH11K_TRACING \
+	ATH11K_TRACING \
 	ATH6KL_TRACING \
 	ATH_TRACEPOINTS \
 	ATH5K_TRACER \
@@ -292,7 +292,7 @@ define KernelPackage/ath11k
   TITLE:=Qualcomm 802.11ax wireless chipset support (common code)
   URL:=https://wireless.wiki.kernel.org/en/users/drivers/ath11k
   DEPENDS+= +kmod-ath +@DRIVER_11N_SUPPORT +@DRIVER_11AC_SUPPORT +@DRIVER_11AX_SUPPORT \
-  +kmod-crypto-michael-mic +ATH11K_THERMAL:kmod-hwmon-core +ATH11K_THERMAL:kmod-thermal
+	+kmod-crypto-michael-mic +ATH11K_THERMAL:kmod-hwmon-core +ATH11K_THERMAL:kmod-thermal
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath11k/ath11k.ko
   AUTOLOAD:=$(call AutoProbe,ath11k)
 endef
@@ -367,7 +367,7 @@ endef
 define KernelPackage/ar5523
   $(call KernelPackage/mac80211/Default)
   TITLE:=Driver for Atheros AR5523 USB sticks
-  DEPENDS:=@USB_SUPPORT +kmod-mac80211 +kmod-ath +kmod-usb-core +kmod-input-core 
+  DEPENDS:=@USB_SUPPORT +kmod-mac80211 +kmod-ath +kmod-usb-core +kmod-input-core
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ar5523/ar5523.ko
   AUTOLOAD:=$(call AutoProbe,ar5523)
 endef

--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -135,7 +135,7 @@ mac80211_hostapd_setup_base() {
 	[ -n "$acs_exclude_dfs" ] && [ "$acs_exclude_dfs" -gt 0 ] &&
 		append base_cfg "acs_exclude_dfs=1" "$N"
 
-	json_get_vars noscan ht_coex
+	json_get_vars noscan ht_coex vendor_vht
 	json_get_values ht_capab_list ht_capab tx_burst
 	json_get_values channel_list channels
 
@@ -280,7 +280,7 @@ mac80211_hostapd_setup_base() {
 	}
 	[ "$hwmode" = "a" ] || enable_ac=0
 
-	if [ "$enable_ac" != "0" ]; then
+	if [ "$enable_ac" != "0" -o "$vendor_vht" = "1" ]; then
 		json_get_vars \
 			rxldpc:1 \
 			short_gi_80:1 \

--- a/package/kernel/mac80211/patches/ath10k/983-ath10k-allow-vht-on-2g.patch
+++ b/package/kernel/mac80211/patches/ath10k/983-ath10k-allow-vht-on-2g.patch
@@ -1,0 +1,10 @@
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -4841,6 +4841,7 @@ static void ath10k_mac_setup_ht_vht_cap(
+ 	if (ar->phy_capability & WHAL_WLAN_11G_CAPABILITY) {
+ 		band = &ar->mac.sbands[NL80211_BAND_2GHZ];
+ 		band->ht_cap = ht_cap;
++		band->vht_cap = vht_cap;
+ 	}
+ 	if (ar->phy_capability & WHAL_WLAN_11A_CAPABILITY) {
+ 		band = &ar->mac.sbands[NL80211_BAND_5GHZ];

--- a/package/kernel/mac80211/patches/subsys/600-mac80211-allow-vht-on-2g.patch
+++ b/package/kernel/mac80211/patches/subsys/600-mac80211-allow-vht-on-2g.patch
@@ -1,0 +1,36 @@
+--- a/net/mac80211/vht.c
++++ b/net/mac80211/vht.c
+@@ -135,7 +135,8 @@ ieee80211_vht_cap_ie_to_sta_vht_cap(stru
+ 	have_80mhz = false;
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1906,7 +1906,8 @@ static int ieee80211_build_preq_ies_band
+ 	/* Check if any channel in this sband supports at least 80 MHz */
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -5068,7 +5068,8 @@ static int ieee80211_prep_channel(struct
+ 	have_80mhz = false;
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -104,6 +104,7 @@ hostapd_common_add_device_config() {
 	config_add_int rssi_reject_assoc_rssi
 	config_add_int rssi_ignore_probe_request
 	config_add_int maxassoc
+	config_add_boolean vendor_vht
 
 	config_add_string acs_chan_bias
 	config_add_array hostapd_options
@@ -121,7 +122,7 @@ hostapd_prepare_device_config() {
 
 	json_get_vars country country3 country_ie beacon_int:100 dtim_period:2 doth require_mode legacy_rates \
 		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode cell_density \
-		rts_threshold beacon_rate rssi_reject_assoc_rssi rssi_ignore_probe_request maxassoc
+		rts_threshold beacon_rate rssi_reject_assoc_rssi rssi_ignore_probe_request maxassoc vendor_vht
 
 	hostapd_set_log_options base_cfg
 
@@ -190,6 +191,7 @@ hostapd_prepare_device_config() {
 				set_default rate_list "24000 36000 48000 54000"
 				set_default basic_rate_list "24000"
 			fi
+			[ -n "$vendor_vht" ] && append base_cfg "vendor_vht=$vendor_vht" "$N"
 		;;
 		a)
 			if [ "$cell_density" -eq 1 ]; then


### PR DESCRIPTION
* mac80211: allow VHT on 2.4GHz

Allow VHT rate on 2.4GHz in order to use 256-QAM

Signed-off-by: DENG Qingfang <dengqf6@mail2.sysu.edu.cn>

* ath10k: allow VHT on 2.4GHz

Signed-off-by: DENG Qingfang <dengqf6@mail2.sysu.edu.cn>

* hostapd: add vendor_vht option

hostapd has vendor_vht option to enable VHT (256-QAM) on 2.4GHz
Add this option to hostapd.sh so users can enable it via uci

Signed-off-by: DENG Qingfang <dengqf6@mail2.sysu.edu.cn>

* mac80211: ath.mk: typo fixes

Co-authored-by: DENG Qingfang <dengqf6@mail2.sysu.edu.cn>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
