### PR TITLE
hostapd: fix broken check in radar detection notification (#7663)

### DIFF
--- a/package/network/services/hostapd/src/src/ap/ubus.c
+++ b/package/network/services/hostapd/src/src/ap/ubus.c
@@ -1741,9 +1741,6 @@ void hostapd_ubus_notify_radar_detected(struct hostapd_iface *iface, int frequen
 	struct hostapd_data *hapd;
 	int i;
 
-	if (!hapd->ubus.obj.has_subscribers)
-		return;
-
 	blob_buf_init(&b, 0);
 	blobmsg_add_u16(&b, "frequency", frequency);
 	blobmsg_add_u16(&b, "width", chan_width);


### PR DESCRIPTION
This check was accidentally left in after reworking the code,
causing a segfault

Signed-off-by: Felix Fietkau <nbd@nbd.name>

Co-authored-by: Felix Fietkau <nbd@nbd.name>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道