### PR TITLE
luci-app-softethervpn: update provided links for SoftEtherVPN clients…

### DIFF
--- a/package/lean/luci-app-softethervpn/Makefile
+++ b/package/lean/luci-app-softethervpn/Makefile
@@ -9,7 +9,7 @@ LUCI_TITLE:=LuCI support for SoftEtherVPN
 LUCI_DEPENDS:=+zlib +libpthread +librt +libreadline +libncurses +libiconv-full +kmod-tun +libopenssl +softethervpn5-bridge +softethervpn5-client +softethervpn5-server
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/package/lean/luci-app-softethervpn/luasrc/model/cbi/softethervpn.lua
+++ b/package/lean/luci-app-softethervpn/luasrc/model/cbi/softethervpn.lua
@@ -13,6 +13,6 @@ s.anonymous = true
 o = s:option(Flag, "enable", translate("Enabled"))
 o.rmempty = false
 
-o = s:option(DummyValue, "moreinfo", translate("<strong>控制台下载：<a onclick=\"window.open('https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/releases/download/v4.30-9696-beta/softether-vpnserver_vpnbridge-v4.30-9696-beta-2019.07.08-windows-x86_x64-intel.exe')\"><br/>Windows-x86_x64-intel.exe</a><a  onclick=\"window.open('https://www.softether-download.com/files/softether/v4.21-9613-beta-2016.04.24-tree/Mac_OS_X/Admin_Tools/VPN_Server_Manager_Package/softether-vpnserver_manager-v4.21-9613-beta-2016.04.24-macos-x86-32bit.pkg')\"><br/>macos-x86-32bit.pkg</a></strong>"))
+o = s:option(DummyValue, "moreinfo", translate("<strong>控制台下载：<a onclick=\"window.open('https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/releases/download/v4.38-9760-rtm/softether-vpnclient-v4.38-9760-rtm-2021.08.17-windows-x86_x64-intel.exe')\"><br/>Windows-x86_x64-intel.exe</a><a  onclick=\"window.open('https://github.com/SoftEtherVPN/SoftEtherVPN_Stable/releases/download/v4.38-9760-rtm/softether-vpnclient-v4.38-9760-rtm-2021.08.17-macos-x86-32bit.tar.gz')\"><br/>macos-x86-32bit.pkg</a></strong>"))
 
 return m


### PR DESCRIPTION
… (#8435)

I updated the link for downloading Windows client to download the latest
currently available version instead of using beta version, which is not
good to use in production.

Also, the macOS link led to the OpenVPN server, which was wrong. It should
be a client. It was updated to the latest version as well.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
