### PR TITLE
Apply BCM578xx sfp2.5g patch to test 5.15 kernel (#8615)

### DIFF
--- a/target/linux/x86/patches-5.15/993-bnx2x_warpcore_8727_2_5g_sgmii_txfault.patch
+++ b/target/linux/x86/patches-5.15/993-bnx2x_warpcore_8727_2_5g_sgmii_txfault.patch
@@ -1,0 +1,220 @@
+diff -Naur a/drivers/net/ethernet/broadcom/bnx2x/bnx2x.h b/drivers/net/ethernet/broadcom/bnx2x/bnx2x.h
+--- a/drivers/net/ethernet/broadcom/bnx2x/bnx2x.h	2020-09-03 23:21:36.695693427 -0400
++++ b/drivers/net/ethernet/broadcom/bnx2x/bnx2x.h	2020-09-03 23:29:22.457340229 -0400
+@@ -1592,6 +1592,7 @@
+ 	uint			num_ethernet_queues;
+ 	uint			num_cnic_queues;
+ 	int			disable_tpa;
++	int			mask_tx_fault;
+ 
+ 	u32			rx_mode;
+ #define BNX2X_RX_MODE_NONE		0
+diff -Naur a/drivers/net/ethernet/broadcom/bnx2x/bnx2x_link.c b/drivers/net/ethernet/broadcom/bnx2x/bnx2x_link.c
+--- a/drivers/net/ethernet/broadcom/bnx2x/bnx2x_link.c	2020-09-03 23:21:36.699693373 -0400
++++ b/drivers/net/ethernet/broadcom/bnx2x/bnx2x_link.c	2020-09-03 23:29:22.457340229 -0400
+@@ -151,6 +151,7 @@
+ 
+ #define SFP_EEPROM_CON_TYPE_ADDR		0x2
+ 	#define SFP_EEPROM_CON_TYPE_VAL_UNKNOWN	0x0
++	#define SFP_EEPROM_CON_TYPE_VAL_SC	0x1
+ 	#define SFP_EEPROM_CON_TYPE_VAL_LC	0x7
+ 	#define SFP_EEPROM_CON_TYPE_VAL_COPPER	0x21
+ 	#define SFP_EEPROM_CON_TYPE_VAL_RJ45	0x22
+@@ -4206,6 +4207,16 @@
+ 					 0x1000);
+ 		DP(NETIF_MSG_LINK, "set SGMII AUTONEG\n");
+ 	} else {
++		/* Note that 2.5G works only when used with 1G advertisment */
++		if (fiber_mode && (phy->req_line_speed == SPEED_2500) &&
++			(phy->speed_cap_mask &
++			 (PORT_HW_CFG_SPEED_CAPABILITY_D0_1G |
++			  PORT_HW_CFG_SPEED_CAPABILITY_D0_2_5G))) {
++			bnx2x_cl45_write(bp, phy, MDIO_WC_DEVAD,
++				MDIO_WC_REG_SERDESDIGITAL_MISC1,
++					0x6010);
++		}
++
+ 		bnx2x_cl45_read(bp, phy, MDIO_WC_DEVAD,
+ 				MDIO_WC_REG_COMBO_IEEE0_MIICTRL, &val16);
+ 		val16 &= 0xcebf;
+@@ -4216,6 +4227,7 @@
+ 			val16 |= 0x2000;
+ 			break;
+ 		case SPEED_1000:
++		case SPEED_2500:
+ 			val16 |= 0x0040;
+ 			break;
+ 		default:
+@@ -8169,6 +8181,7 @@
+ 		break;
+ 	}
+ 	case SFP_EEPROM_CON_TYPE_VAL_UNKNOWN:
++	case SFP_EEPROM_CON_TYPE_VAL_SC:
+ 	case SFP_EEPROM_CON_TYPE_VAL_LC:
+ 	case SFP_EEPROM_CON_TYPE_VAL_RJ45:
+ 		check_limiting_mode = 1;
+@@ -8179,7 +8192,8 @@
+ 		    (val[SFP_EEPROM_1G_COMP_CODE_ADDR] != 0)) {
+ 			DP(NETIF_MSG_LINK, "1G SFP module detected\n");
+ 			phy->media_type = ETH_PHY_SFP_1G_FIBER;
+-			if (phy->req_line_speed != SPEED_1000) {
++			if ((phy->req_line_speed != SPEED_1000) &&
++				(phy->req_line_speed != SPEED_2500)) {
+ 				u8 gport = params->port;
+ 				phy->req_line_speed = SPEED_1000;
+ 				if (!CHIP_IS_E1x(bp)) {
+@@ -8411,7 +8425,7 @@
+ 	 * some phys type ( e.g. JDSU )
+ 	 */
+ 
+-	for (timeout = 0; timeout < 60; timeout++) {
++	for (timeout = 0; timeout < 1800; timeout++) {
+ 		if (phy->type == PORT_HW_CFG_XGXS_EXT_PHY_TYPE_DIRECT)
+ 			rc = bnx2x_warpcore_read_sfp_module_eeprom(
+ 				phy, params, I2C_DEV_ADDR_A0, 1, 1, &val,
+@@ -9238,6 +9252,7 @@
+ 	u16 tmp1, val;
+ 	/* Set option 1G speed */
+ 	if ((phy->req_line_speed == SPEED_1000) ||
++		(phy->req_line_speed == SPEED_2500) ||
+ 	    (phy->media_type == ETH_PHY_SFP_1G_FIBER)) {
+ 		DP(NETIF_MSG_LINK, "Setting 1G force\n");
+ 		bnx2x_cl45_write(bp, phy,
+@@ -9247,6 +9262,22 @@
+ 		bnx2x_cl45_read(bp, phy,
+ 				MDIO_PMA_DEVAD, MDIO_PMA_REG_10G_CTRL2, &tmp1);
+ 		DP(NETIF_MSG_LINK, "1.7 = 0x%x\n", tmp1);
++		if ((phy->req_line_speed == SPEED_2500) &&
++			(phy->speed_cap_mask &
++			(PORT_HW_CFG_SPEED_CAPABILITY_D0_1G |
++			 PORT_HW_CFG_SPEED_CAPABILITY_D0_2_5G))) {
++			bnx2x_cl45_read_and_write(bp, phy,
++					MDIO_AN_DEVAD,
++					MDIO_AN_REG_8727_MISC_CTRL2,
++					~(1<<5));
++			bnx2x_cl45_write(bp, phy,
++					MDIO_AN_DEVAD,
++					MDIO_AN_REG_8727_MISC_CTRL1, 0x0010);
++		} else {
++			bnx2x_cl45_write(bp, phy,
++					MDIO_AN_DEVAD,
++					MDIO_AN_REG_8727_MISC_CTRL1, 0x001C);
++		}
+ 		/* Power down the XAUI until link is up in case of dual-media
+ 		 * and 1G
+ 		 */
+@@ -9268,7 +9299,7 @@
+ 
+ 		DP(NETIF_MSG_LINK, "Setting 1G clause37\n");
+ 		bnx2x_cl45_write(bp, phy,
+-				 MDIO_AN_DEVAD, MDIO_AN_REG_8727_MISC_CTRL, 0);
++				 MDIO_AN_DEVAD, MDIO_AN_REG_8727_MISC_CTRL2, 0);
+ 		bnx2x_cl45_write(bp, phy,
+ 				 MDIO_AN_DEVAD, MDIO_AN_REG_CL37_AN, 0x1300);
+ 	} else {
+@@ -9276,9 +9307,12 @@
+ 		 * registers although it is default
+ 		 */
+ 		bnx2x_cl45_write(bp, phy,
+-				 MDIO_AN_DEVAD, MDIO_AN_REG_8727_MISC_CTRL,
++				 MDIO_AN_DEVAD, MDIO_AN_REG_8727_MISC_CTRL2,
+ 				 0x0020);
+ 		bnx2x_cl45_write(bp, phy,
++				 MDIO_AN_DEVAD, MDIO_AN_REG_8727_MISC_CTRL1,
++				 0x001C);
++		bnx2x_cl45_write(bp, phy,
+ 				 MDIO_AN_DEVAD, MDIO_AN_REG_CL37_AN, 0x0100);
+ 		bnx2x_cl45_write(bp, phy,
+ 				 MDIO_PMA_DEVAD, MDIO_PMA_REG_CTRL, 0x2040);
+@@ -9569,6 +9603,11 @@
+ 		vars->line_speed = SPEED_10000;
+ 		DP(NETIF_MSG_LINK, "port %x: External link up in 10G\n",
+ 			   params->port);
++	} else if ((link_status & (1<<1)) && (!(link_status & (1<<14)))) {
++		link_up = 1;
++		vars->line_speed = SPEED_2500;
++		DP(NETIF_MSG_LINK, "port %x: External link up in 2.5G\n",
++			   params->port);
+ 	} else if ((link_status & (1<<0)) && (!(link_status & (1<<13)))) {
+ 		link_up = 1;
+ 		vars->line_speed = SPEED_1000;
+@@ -9600,7 +9639,8 @@
+ 	}
+ 
+ 	if ((DUAL_MEDIA(params)) &&
+-	    (phy->req_line_speed == SPEED_1000)) {
++	    ((phy->req_line_speed == SPEED_1000) ||
++	     (phy->req_line_speed == SPEED_2500))) {
+ 		bnx2x_cl45_read(bp, phy,
+ 				MDIO_PMA_DEVAD,
+ 				MDIO_PMA_REG_8727_PCS_GP, &val1);
+@@ -11730,6 +11770,7 @@
+ 			   SUPPORTED_100baseT_Full |
+ 			   SUPPORTED_1000baseT_Full |
+ 			   SUPPORTED_1000baseKX_Full |
++			   SUPPORTED_2500baseX_Full |
+ 			   SUPPORTED_10000baseT_Full |
+ 			   SUPPORTED_10000baseKR_Full |
+ 			   SUPPORTED_20000baseKR2_Full |
+@@ -11916,6 +11957,7 @@
+ 	.tx_preemphasis	= {0xffff, 0xffff, 0xffff, 0xffff},
+ 	.mdio_ctrl	= 0,
+ 	.supported	= (SUPPORTED_10000baseT_Full |
++			   SUPPORTED_2500baseX_Full |
+ 			   SUPPORTED_1000baseT_Full |
+ 			   SUPPORTED_FIBRE |
+ 			   SUPPORTED_Pause |
+@@ -12263,6 +12305,7 @@
+ 			break;
+ 		case PORT_HW_CFG_NET_SERDES_IF_SFI:
+ 			phy->supported &= (SUPPORTED_1000baseT_Full |
++					   SUPPORTED_2500baseX_Full |
+ 					   SUPPORTED_10000baseT_Full |
+ 					   SUPPORTED_FIBRE |
+ 					   SUPPORTED_Pause |
+@@ -13947,7 +13990,8 @@
+ 		    & PORT_HW_CFG_NET_SERDES_IF_MASK) ==
+ 		    PORT_HW_CFG_NET_SERDES_IF_SFI) {
+ 			if (bnx2x_is_sfp_module_plugged(phy, params)) {
+-				bnx2x_sfp_tx_fault_detection(phy, params, vars);
++				if(!((params->port + 1) & bp->mask_tx_fault))
++					bnx2x_sfp_tx_fault_detection(phy, params, vars);
+ 			} else if (vars->link_status &
+ 				LINK_STATUS_SFP_TX_FAULT) {
+ 				/* Clean trail, interrupt corrects the leds */
+diff -Naur a/drivers/net/ethernet/broadcom/bnx2x/bnx2x_main.c b/drivers/net/ethernet/broadcom/bnx2x/bnx2x_main.c
+--- a/drivers/net/ethernet/broadcom/bnx2x/bnx2x_main.c	2020-09-03 23:21:36.699693373 -0400
++++ b/drivers/net/ethernet/broadcom/bnx2x/bnx2x_main.c	2020-09-03 23:29:22.461340175 -0400
+@@ -105,6 +105,10 @@
+ module_param(disable_tpa, int, 0444);
+ MODULE_PARM_DESC(disable_tpa, " Disable the TPA (LRO) feature");
+ 
++static int mask_tx_fault;
++module_param(mask_tx_fault, int, 0444);
++MODULE_PARM_DESC(mask_tx_fault, " Mask SFP TX fault detection");
++
+ static int int_mode;
+ module_param(int_mode, int, 0444);
+ MODULE_PARM_DESC(int_mode, " Force interrupt mode other than MSI-X "
+@@ -12455,6 +12459,8 @@
+ 	if (BP_NOMCP(bp) && (func == 0))
+ 		dev_err(&bp->pdev->dev, "MCP disabled, must load devices in order!\n");
+ 
++	bp->mask_tx_fault = mask_tx_fault;
++
+ 	bp->disable_tpa = disable_tpa;
+ 	bp->disable_tpa |= !!IS_MF_STORAGE_ONLY(bp);
+ 	/* Reduce memory usage in kdump environment by disabling TPA */
+diff -Naur a/drivers/net/ethernet/broadcom/bnx2x/bnx2x_reg.h b/drivers/net/ethernet/broadcom/bnx2x/bnx2x_reg.h
+--- a/drivers/net/ethernet/broadcom/bnx2x/bnx2x_reg.h	2020-09-03 23:21:36.699693373 -0400
++++ b/drivers/net/ethernet/broadcom/bnx2x/bnx2x_reg.h	2020-09-03 23:22:22.975062197 -0400
+@@ -7169,7 +7169,8 @@
+ #define MDIO_PMA_REG_8727_PCS_GP		0xc842
+ #define MDIO_PMA_REG_8727_OPT_CFG_REG		0xc8e4
+ 
+-#define MDIO_AN_REG_8727_MISC_CTRL		0x8309
++#define MDIO_AN_REG_8727_MISC_CTRL1		0x8308
++#define MDIO_AN_REG_8727_MISC_CTRL2		0x8309
+ 
+ #define MDIO_PMA_REG_8073_CHIP_REV			0xc801
+ #define MDIO_PMA_REG_8073_SPEED_LINK_STATUS		0xc820


### PR DESCRIPTION
* kernel: add module for  bcm574xx 575xx serials

kernel: add module for bnxt_en Linux driver for the 
Broadcom NetXtreme-C/NetXtreme-E 
BCM573xx, BCM574xx, BCM575xx, NetXtreme-S BCM5880x
(up to 200 Gbps) Ethernet Network Controllers and Broadcom Nitro
BCM58700 4-port 1/2.5/10 Gbps Ethernet Network Controller.

* reapply bcm578xx sfp 2.5g patch

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
